### PR TITLE
Ignore income bonus when using catalog asset too late

### DIFF
--- a/cityofthebigshoulders.game.php
+++ b/cityofthebigshoulders.game.php
@@ -5809,6 +5809,9 @@ class CityOfTheBigShoulders extends Table
                 'player_id' => $next_player_id
             ));
 
+            // reset all companies income (needed when using Catalog asset after income was distributed)
+            self::DbQuery("UPDATE company SET income = 0");
+
             // deal buildings
             $round = self::getGameStateValue('round');
             if($round > 0)


### PR DESCRIPTION
* https://boardgamearena.com/bug?id=20907
* Income bonus is ignored when catalog asset is activate in final state
* Reset income in SQL at phase 1 was another possibility