### PR TITLE
ConfirmBuyResources: Include available cash in text

### DIFF
--- a/cityofthebigshoulders.js
+++ b/cityofthebigshoulders.js
@@ -3858,9 +3858,10 @@ function (dojo, declare) {
             total += items.length * 30;
 
             this.setClientState("client_playerTurnConfirmBuyResources", {
-                descriptionmyturn : dojo.string.substitute(_('Buy ${count} resources for $${cost}'),{
+                descriptionmyturn : dojo.string.substitute(_('Buy ${count} resources for $${cost} ($${cash} is available)'),{
                     count: count,
-                    cost: total
+                    cost: total,
+                    cash: this.gamedatas.counters['money_' + this.gamedatas.gamestate.args.company_short_name].counter_value,
                 })
             });
         },


### PR DESCRIPTION
* Mainly useful when have multiple companies. At least that help me a lot while testing the new supply variant.
* ![image](https://user-images.githubusercontent.com/70916547/97087025-f6197880-15f4-11eb-9623-c697f152d188.png)
